### PR TITLE
Handle daemon-reload now

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,7 @@
 # TODO: Need to have a check here to make sure vault started all right.
 # TODO: Need to do a daemon reload here as well.
 - name: Restart vault
-  service: name=vault state=restarted
+  systemd:
+    name: vault
+    state: restarted
+    daemon_reload: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -172,6 +172,7 @@
     - not ansible_os_family == "FreeBSD"
     - not ansible_os_family == "Solaris"
     - systemd_version is defined
+  notify: Restart vault
 
 - name: Start Vault
   service:


### PR DESCRIPTION
Previous implementation didn't handle a systemd based system for
change in the systemd template file.  Therefore changed the notify
handler to do a daemon reload.  This probably breaks all the other
service implementations.